### PR TITLE
Add information about adding plugin in K8s hosted GoCD

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,25 @@ Eg:
 -Dgo.plugin.build.status.white_listed_pipeline_group=internal,dev
 ```
 
+## Configuring the plugin for GoCD on Kubernetes using Helm
+
+### Adding the plugin
+- In order to add this plugin, you have to use a local values.yaml file that will override the default [values.yaml](https://github.com/helm/charts/blob/master/stable/gocd/values.yaml) present in the official GoCD helm chart repo.
+- Add the .jar file link from the releases section to the `env.extraEnvVars` section as a new environment variable.
+- The environment variable name must have `GOCD_PLUGIN_INSTALL` prefixed to it.
+- Example
+
+```
+env:
+  extraEnvVars:
+    - name: GOCD_PLUGIN_INSTALL_gitternotifier
+      value: https://github.com/gocd-contrib/gitter-notifier/releases/download/v2.1.0/gitter-notification-plugin-2.1.0.jar
+```
+
+- Make sure to add the link of the release you want to use.
+
+- Then applying the local values.yaml that has these values added to it will result in a new Go Server pod being created that has the plugin installed and running.
+
 [1]: images/list-plugin.png  "List Plugin"
 [2]: images/configure-plugin.png  "Configure Plugin"
 [3]: images/gitter-notification.png  "Successful Notification"


### PR DESCRIPTION
This PR should help people who have their GoCD setup hosted on Kubernetes to add this plugin to their instance.

It contains information on how to add the plugin jar file to the values.yaml.

Co-authored-by: Nithya S <nithyasbe@gmail.com>
Co-authored-by: Mohamed Najiullah <mohammed.najiullah@gmail.com>